### PR TITLE
Peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     },
     "peerDependencies": {
         "react": ">=16.13.1",
-        "@babel/polyfill": ">=7.00.1"
+        "@babel/polyfill": ">=7.12.1"
     },
     "devDependencies": {
         "@babel/cli": "^7.17.10",

--- a/package.json
+++ b/package.json
@@ -19,9 +19,9 @@
         "type": "git",
         "url": "git+https://github.com/winter-crypto/checkout-package.git"
     },
-    "dependencies": {
-        "@babel/polyfill": "^7.12.1",
-        "react": "^17.0.2"
+    "peerDependencies": {
+        "react": ">=16.13.1",
+        "@babel/polyfill": ">=7.00.1"
     },
     "devDependencies": {
         "@babel/cli": "^7.17.10",


### PR DESCRIPTION
This means we use the version that is already in the package.json of the codebase if it is above these versions. This will stop us from having two versions of these packages, potentially solving react issue. This is from React's website on the error message I have been getting. "If you see more than one React, you’ll need to figure out why this happens and fix your dependency tree. For example, maybe a library you’re using incorrectly specifies react as a dependency (rather than a peer dependency). Until that library is fixed, [Yarn resolutions](https://yarnpkg.com/lang/en/docs/selective-version-resolutions/) is one possible workaround."

This is another message that seems related from https://github.com/facebook/react/issues/13991 "Yup, i tried to [npm link](http://www.deadcoderising.com/how-to-smoothly-develop-node-modules-locally-using-npm-link/) a package i'm creating. It throws that same error since the other package is also using hooks but with its own React. I had to publish my package to NPM and then import it directly from NPM. That way the error was gone, but i hope this is fixed since publishing a package without testing it is bad, obviously" 

I'm thinking we need to redeploy the package and see if that works. 